### PR TITLE
feat: major refactor

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -15,9 +15,9 @@ const track = (effect: () => void) => {
 
 const watch = (obj: object) => {
   const spy = jest.fn()
-  const observer = { observed: new Set(), _onChange: spy }
-  obj[$O].add($O, observer)
-  obj[$O].add(SIZE, observer)
+  const observer = { onChange: spy }
+  obj[$O].get($O).add(observer)
+  obj[$O].get(SIZE).add(observer)
   return spy.mock.calls
 }
 

--- a/spec/render.spec.tsx
+++ b/spec/render.spec.tsx
@@ -4,9 +4,9 @@ import { o, useAuto, withAuto } from '../src'
 import { Auto } from '../src/auto'
 
 beforeAll(() => {
-  const update = Auto.prototype['_onDelay']
-  Auto.prototype['_onDelay'] = function() {
-    act(() => void update.call(this))
+  const onDelay = Auto.prototype['_onDelay']
+  Auto.prototype['_onDelay'] = function(update) {
+    onDelay.call(this, () => void act(update))
   }
 })
 

--- a/spec/when.spec.ts
+++ b/spec/when.spec.ts
@@ -89,4 +89,12 @@ describe('when()', () => {
       expect(reject).toBeCalled()
     })
   })
+
+  describe('resolved promise', () => {
+    it.todo('stops observing every value')
+  })
+
+  describe('rejected promise', () => {
+    it.todo('stops observing every value')
+  })
 })

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -1,79 +1,143 @@
 import { isUndefined, noop, rethrowError } from './common'
 import { track } from './global'
-import { Observer } from './observable'
+import { ObservedValue, Observer } from './observable'
 import { $O } from './symbols'
 
 /** Run an effect when its tracked values change. */
 export function auto(effect: () => void, config?: AutoConfig) {
   const auto = new Auto(config || {})
   auto.run(effect)
+  auto.commit(true)
   return auto
 }
 
 export interface AutoConfig {
+  /** By default, delay changes until the next microtask loop */
   delay?: number | boolean
-  /** By default, calls the `run` method with the previous effect */
+  /** By default, rerun the last effect */
   onDirty?: Auto['onDirty']
+  /** By default, attach the `update` callback to a promise or timeout */
+  onDelay?: Auto['onDelay']
   /** By default, errors are rethrown */
   onError?: Auto['onError']
 }
 
-export class Auto extends Observer {
+export class Auto {
   dirty = true
   delay: number | boolean
   onDirty: (this: Auto) => void
+  onDelay: (this: Auto, update: () => void) => void
   onError: (this: Auto, error: Error) => void
-  prevEffect = noop
+  lastObserver: AutoObserver | null = null
+  lastEffect = noop
+  nextObserver: AutoObserver | null = null
+  nextEffect = noop
 
   constructor(config: AutoConfig = {}) {
-    super()
     this.delay = isUndefined(config.delay) || config.delay
     this.onDirty = config.onDirty || this.rerun
+    this.onDelay = config.onDelay || this._onDelay
     this.onError = config.onError || rethrowError
   }
 
   run<T>(effect: () => T): T | undefined {
-    const { observed } = this
-    this.observed = new Set()
     let result: T | undefined
     try {
-      result = track(effect, (target, key) => target[$O].add(key, this))
-      this.prevEffect = effect
+      const observed = new Set<ObservedValue>()
+      result = track(effect, (target, key) => {
+        observed.add(target[$O]!.get(key))
+      })
+      this.nextObserver = new AutoObserver(observed)
+      this.nextEffect = effect
       this.dirty = false
     } catch (error) {
-      this.observed.clear()
+      this.dirty = false
       this.onError(error)
-    } finally {
-      observed.forEach(set => {
-        if (!this.observed.has(set)) {
-          set.owner.remove(set.key, this)
-        }
-      })
     }
     return result
   }
 
+  /** Rerun the last effect and commit its observer */
   rerun() {
-    this.run(this.prevEffect)
+    this.run(this.lastEffect)
+    this.commit(true)
+  }
+
+  /** Commit the observer from the last run, except when the observer is dirty */
+  commit(force?: boolean) {
+    const observer = this.nextObserver
+    if (observer) {
+      this.nextObserver = null
+      if (this.lastObserver) {
+        this.lastObserver.dispose()
+      }
+
+      this.lastEffect = this.nextEffect
+      this.nextEffect = noop
+
+      // Check for changes between run and commit.
+      if (!force && observer.dirty) {
+        this.lastObserver = null
+        return false
+      }
+
+      observer.values = null
+      observer.onChange = this._onChange.bind(this)
+      observer.observed.forEach(value => value.add(observer!))
+      this.lastObserver = observer
+    }
+    return true
+  }
+
+  dispose() {
+    const observer = this.lastObserver
+    if (observer) {
+      observer.dispose()
+      // Prevent delayed changes.
+      this.lastObserver = null
+    }
+    // Prevent the next commit.
+    this.nextObserver = null
   }
 
   protected _onChange() {
     if (!this.dirty) {
       this.dirty = true
       if (this.delay > 0) {
-        const update = this._onDelay.bind(this)
-        if (this.delay === true) {
-          Promise.resolve().then(update)
-        } else {
-          setTimeout(update, this.delay as any)
-        }
+        const observer = this.lastObserver
+        this.onDelay(() => observer == this.lastObserver && this.onDirty())
       } else {
         this.onDirty()
       }
     }
   }
 
-  protected _onDelay() {
-    if (!this.disposed) this.onDirty()
+  protected _onDelay(update: () => void) {
+    if (this.delay === true) {
+      Promise.resolve().then(update)
+    } else {
+      setTimeout(update, this.delay as any)
+    }
+  }
+}
+
+export class AutoObserver extends Observer {
+  values: any[] | null = []
+  onChange: (() => void) | null = null
+
+  constructor(readonly observed: ReadonlySet<ObservedValue>) {
+    super()
+    observed.forEach(value => {
+      this.values!.push(value.get())
+    })
+  }
+
+  /** Returns false when the observed values are still current */
+  get dirty() {
+    const { values } = this
+    return (
+      !values ||
+      Array.from(this.observed).some((value, i) => values[i] !== value.get())
+    )
   }
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,17 +1,19 @@
+import { ObservedState } from './observable'
+
 export const global: {
-  observe: ((target: object, key: any) => void) | null
+  observe: ((obj: ObservedState, key: any) => void) | null
 } = {
   observe: null,
 }
 
 /** Tell the current observer to track the given object/key pair  */
-export const observe = (obj: object, key: any) =>
+export const observe = (obj: ObservedState, key: any) =>
   !!global.observe && (global.observe(obj, key), true)
 
 /** Run an effect and track any observable values it uses */
 export function track<T>(
   effect: () => T,
-  observe: (target: object, key: any) => void
+  observe: (obj: ObservedState, key: any) => void
 ): T {
   if (global.observe) {
     throw Error('Recursive "track" calls are forbidden')

--- a/src/render.ts
+++ b/src/render.ts
@@ -6,6 +6,7 @@ import {
   RefAttributes,
   RefForwardingComponent,
   useEffect,
+  useLayoutEffect,
   useReducer,
 } from 'react'
 import { useMemoOne as useMemo } from 'use-memo-one'
@@ -36,6 +37,9 @@ export function withAuto(render: any) {
     const onDirty = useForceUpdate()
     const auto = useConstant(() => new Auto({ onDirty }))
     useDispose(() => auto.dispose())
+    useLayoutEffect(() => {
+      if (!auto.commit()) onDirty()
+    })
     return auto.run(() => render(props, ref))
   }
   // prettier-ignore
@@ -50,6 +54,7 @@ export function useAuto(effect: () => void, deps?: any[]) {
   useDispose(() => auto.dispose())
   useEffect(() => {
     auto.run(effect)
+    auto.commit(true)
   }, deps)
 }
 

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,6 +1,10 @@
 import { isMap, isObject, isUndefined } from './common'
-import { Change, Observer } from './observable'
+import { Change, ObservedState, ObservedValue, Observer } from './observable'
 import { $O } from './symbols'
+
+type WatchedState = ObservedState & {
+  forEach?: (cb: (value: any, key: any, ctx: any) => void) => void
+}
 
 /** Watch an observable tree for changes */
 export function watch(root: object, onChange: (change: Change) => void) {
@@ -12,13 +16,29 @@ export function watch(root: object, onChange: (change: Change) => void) {
 
 /** An observer of deep changes */
 export class Watcher extends Observer {
+  observed = new Set<ObservedValue>()
   counts = new Map<object, number>()
 
-  constructor(
-    readonly root: object,
-    readonly onChange: (change: Change) => void
-  ) {
+  constructor(readonly root: object, onChange: (change: Change) => void) {
     super()
+    this.onChange = change => {
+      const { op, target, key, value, oldValue } = change
+      switch (op) {
+        case 'replace':
+          if (isObject(oldValue)) this._unwatch(oldValue)
+        case 'add':
+          this.watch(value, key, target)
+          break
+        case 'remove':
+          this.unwatch(value, key, target)
+          break
+        case 'splice':
+          value.forEach(this.watch)
+        default:
+          oldValue.forEach(this.unwatch)
+      }
+      onChange(change)
+    }
     this._watch(root)
   }
 
@@ -33,30 +53,30 @@ export class Watcher extends Observer {
   }
 
   dispose() {
-    if (!this.disposed) {
+    if (this.onChange) {
       super.dispose()
       this.counts.clear()
     }
   }
 
   // Watch every observable in the given object.
-  protected _watch(target: any) {
+  protected _watch(target: WatchedState) {
     const { counts } = this
     const count = counts.get(target) || 0
     counts.set(target, count + 1)
     if (!count) {
       if (target[$O]) {
-        target[$O].add($O, this)
+        this.observed.add(target[$O]!.get($O).add(this))
       }
       if (!target.forEach) {
         target = Object.values(target)
       }
-      target.forEach(this.watch)
+      target.forEach!(this.watch)
     }
   }
 
   // Unwatch every observable in the given object.
-  protected _unwatch(target: any) {
+  protected _unwatch(target: WatchedState) {
     const { counts } = this
     const count = counts.get(target)
     if (isUndefined(count)) return
@@ -65,31 +85,14 @@ export class Watcher extends Observer {
     } else {
       counts.delete(target)
       if (target[$O]) {
-        target[$O].remove($O, this)
+        const value = target[$O]!.get($O)
+        this.observed.delete(value)
+        value.delete(this)
       }
       if (!target.forEach) {
         target = Object.values(target)
       }
-      target.forEach(this.unwatch)
+      target.forEach!(this.unwatch)
     }
-  }
-
-  protected _onChange(change: Change) {
-    const { op, target, key, value, oldValue } = change
-    switch (op) {
-      case 'replace':
-        if (isObject(oldValue)) this._unwatch(oldValue)
-      case 'add':
-        this.watch(value, key, target)
-        break
-      case 'remove':
-        this.unwatch(value, key, target)
-        break
-      case 'splice':
-        value.forEach(this.watch)
-      default:
-        oldValue.forEach(this.unwatch)
-    }
-    this.onChange(change)
   }
 }

--- a/src/when.ts
+++ b/src/when.ts
@@ -6,7 +6,19 @@ import { Auto } from './auto'
  */
 export const when = (condition: () => boolean): Promise<void> =>
   new Promise((resolve, reject) => {
-    const check = () => auto.run(condition) && resolve()
-    const auto = new Auto({ onDirty: check, onError: reject })
-    check()
+    const auto = new Auto({
+      onDirty() {
+        if (this.run(condition)) {
+          this.dispose()
+          resolve()
+        } else {
+          this.commit(true)
+        }
+      },
+      onError(error) {
+        this.dispose()
+        reject(error)
+      },
+    })
+    auto.onDirty()
   })


### PR DESCRIPTION
To reduce memory usage, the `Observable` class now extends the `Map` class instead of using composition. Note: This means you can't use the cjs bundle without polyfilling the `Map` class, because it's impossible to extend the native `Map` class without a `class` declaration.

In the same vein, the `ObserverSet` interface is now the `ObservedValue` class which extends the native `Set` class. The `Observable` class no longer has `add` and `remove` methods. Instead, you'll want to call `get` (which creates an `ObservedValue` on-the-fly if undefined) and add your observer directly using traditional `Set` methods (which `ObservedValue` inherits).

All `ObservedValue` instances live in memory for as long as their `Observable` owner does. This lets us allocate instances during render without needing to worry about cleanup. Besides, rarely does a value get observed just once, so there's really no need to aggressively deallocate unused instances. Even if the value is never observed again, the memory impact is negligible.

The `_onChange` abstract method of `Observer` is now a nullable property. It's nullified when the observer is disposed. Lastly, it's now called `onChange` (no underscore prefix).

The `Auto` class no longer extends the `Observer` class, because it needs the ability to track observable access without immediately observing the tracked observables. To do this, it creates an immutable `AutoObserver` instance that holds a nonce for every observed value. When the `Auto` instance is ready to observe them, call its `commit` method to replace the previous immutable observer. This allows for `Auto` to work in React's concurrent mode, because it no longer needs to subscribe during render. Look at the `withAuto` function in this diff to see the kind of usage `Auto` needs to support.

For clarity, the `run` method of `Auto` no longer registers an observer for any observable values accessed within the effect. You need to call `commit` for that now. If you call `commit` immediately after calling `run`, pass true to avoid an unnecessary dirty check.

The `when` function no longer leaks memory when it resolves or rejects its promise.

The `withAuto` function now checks for changes between render and commit, which triggers a sync re-render to ensure stale data is never displayed to the user.

Added an `onDelay` property to the `AutoConfig` object, which allows for custom scheduling of async reactions.