### PR TITLE
feat: add "global.onChange" function

### DIFF
--- a/src/emit.ts
+++ b/src/emit.ts
@@ -1,4 +1,5 @@
 import { is } from '@alloc/is'
+import { global } from './global'
 import { Change, Observable, ObservedSlot } from './observable'
 import { $O, SIZE } from './symbols'
 
@@ -19,6 +20,9 @@ function onChange(observable: Observable, key: any, change: Change) {
         }
       }
     }
+  }
+  if (global.onChange) {
+    global.onChange(change)
   }
 }
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,5 +1,5 @@
 import { Auto } from './auto'
-import { ObserverTarget } from './observable'
+import { Change, ObserverTarget } from './observable'
 
 type OnRender = (
   auto: Auto,
@@ -16,13 +16,16 @@ interface Global {
   auto: Auto | null
   /** For debugging re-renders. Only called in development. */
   onRender: OnRender | null
+  /** For spying on every change event. */
+  onChange: ((change: Change) => void) | null
 }
 
 export const global: Global = {
-  onRender: () => {},
   batchedUpdates: effect => effect(),
   observe: null,
   auto: null,
+  onRender: null,
+  onChange: null,
 }
 
 /** Tell the current observer to track the given object/key pair  */


### PR DESCRIPTION
This function is called *after* observers are notified, but before any reactions take place.

```js
import { global } from 'wana'

global.onChange = change => {
  console.log(change)
}
```

Closes #17 