### PR TITLE
feat: support synchronous evaluation of a chain of observable getters

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -550,6 +550,31 @@ describe('o(Function)', () => {
     flushSync()
     expectCalls(effect, 1)
   })
+
+  describe('observing another observable getter', () => {
+    it('can rerun synchronously if needed', () => {
+      const state = o({ count: 1 })
+
+      const dub = jest.fn(() => state.count * 2)
+      const dubMemo = o(dub)
+
+      const quad = jest.fn(() => dubMemo() * 2)
+      const quadMemo = o(quad)
+
+      // First run
+      expect(quadMemo()).toBe(4)
+
+      // Change a dependency
+      state.count += 1
+
+      // The affected getter is not called immediately
+      expect(dub).toBeCalledTimes(1)
+
+      // Synchronous rerun
+      expect(quadMemo()).toBe(8)
+      expect(dub).toBeCalledTimes(2)
+    })
+  })
 })
 
 describe('no()', () => {

--- a/src/derive.ts
+++ b/src/derive.ts
@@ -36,6 +36,16 @@ export function derive<T>(run: (auto: Auto) => T): Derived<T> {
     onDirty() {
       if (observable.has($O)) {
         batch.run(derived)
+
+        // Tell our observers to join the next batch to see if our `memo`
+        // value has changed.
+        // Avoid mutating the `nonce` of our observers until our getter
+        // produces a new value (which may never happen).
+        observable.get($O).emit({
+          op: 'clear',
+          target: derived,
+          oldValue: memo,
+        })
       }
     },
   })

--- a/src/emit.ts
+++ b/src/emit.ts
@@ -11,15 +11,7 @@ function onChange(observable: Observable, key: any, change: Change) {
     // Increase the nonce even if no observers exist, because there
     // might be a pending observer (like a "withAuto" component).
     observers.nonce++
-
-    if (observers.size) {
-      // Clone the "observers" in case they get mutated by an effect.
-      for (const observer of Array.from(observers)) {
-        if (observer.onChange) {
-          observer.onChange(change)
-        }
-      }
-    }
+    observers.emit(change)
   }
 }
 

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -87,6 +87,17 @@ export class ObservedSlot extends Set<ChangeObserver> {
   constructor(readonly owner: Observable, readonly key: ObservedKey) {
     super()
   }
+
+  emit(change: Change) {
+    if (this.size) {
+      // Clone the observer list to protect against mutations.
+      for (const observer of Array.from(this)) {
+        if (observer.onChange) {
+          observer.onChange(change)
+        }
+      }
+    }
+  }
 }
 
 /** An observed mutation of an observable object. */


### PR DESCRIPTION
When a value that's being observed by an observable getter is changed, the observable getter should notify its observers that it may change on the next invocation. It does this by using an 
`{ op: 'clear' }` change event. Previously, it would only emit an `{ op: 'replace' }` change on the next invocation, so any observable getter that observes it would be given a stale value if called synchronously (ie: before the batch is flushed).

See the tests in this PR for more details.

Fixes #20