### PR TITLE
Enhance emitSplice for persistance & undo / redo

### DIFF
--- a/src/emit.ts
+++ b/src/emit.ts
@@ -18,8 +18,8 @@ function onChange(observable: Observable, key: any, change: Change) {
 function emit(target: ObserverTarget, change: Change) {
   const observable = target[$O]!
 
-  if (globals.beforeChange) {
-    globals.beforeChange(change)
+  if (globals.onChange) {
+    globals.onChange(change)
   }
 
   // The "clear" op never has a key.
@@ -35,10 +35,6 @@ function emit(target: ObserverTarget, change: Change) {
   // so avoid notifying `$O` observers more than once.
   if (change.key !== SIZE) {
     onChange(observable, $O, change)
-  }
-
-  if (globals.onChange) {
-    globals.onChange(change)
   }
 
   return true

--- a/src/emit.ts
+++ b/src/emit.ts
@@ -18,6 +18,10 @@ function onChange(observable: Observable, key: any, change: Change) {
 function emit(target: ObserverTarget, change: Change) {
   const observable = target[$O]!
 
+  if (globals.beforeChange) {
+    globals.beforeChange(change)
+  }
+
   // The "clear" op never has a key.
   if (change.op !== 'clear') {
     onChange(observable, change.key, change)

--- a/src/emit.ts
+++ b/src/emit.ts
@@ -73,6 +73,7 @@ export const emitReplace = (
 export const emitSplice = (
   target: any[],
   key: number,
+  removeCount: number,
   value: readonly any[],
   oldValue: readonly any[]
 ) =>
@@ -80,6 +81,7 @@ export const emitSplice = (
     op: 'splice',
     target,
     key,
+    removeCount,
     value,
     oldValue,
   })

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -18,8 +18,6 @@ interface Global {
   onRender: OnRender | null
   /** For spying on every change event. */
   onChange: ((change: Change) => void) | null
-  /** For spying *before* every change event. */
-  beforeChange: ((change: Change) => void) | null
 }
 
 export const globals: Global = {
@@ -28,7 +26,6 @@ export const globals: Global = {
   auto: null,
   onRender: null,
   onChange: null,
-  beforeChange: null,
 }
 
 /** Tell the current observer to track the given object/key pair  */

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -18,6 +18,8 @@ interface Global {
   onRender: OnRender | null
   /** For spying on every change event. */
   onChange: ((change: Change) => void) | null
+  /** For spying *before* every change event. */
+  beforeChange: ((change: Change) => void) | null
 }
 
 export const globals: Global = {
@@ -26,6 +28,7 @@ export const globals: Global = {
   auto: null,
   onRender: null,
   onChange: null,
+  beforeChange: null,
 }
 
 /** Tell the current observer to track the given object/key pair  */

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -105,6 +105,7 @@ export interface Change<T = any> {
   op: 'add' | 'replace' | 'remove' | 'splice' | 'clear'
   target: object
   key?: any
+  removeCount?: any
   value?: T
   oldValue?: T
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -41,7 +41,7 @@ const ArrayOverrides: any = {
       const index = oldLength - 1
       const exists = index in self
       const value = self.pop()
-      if (exists) emitRemove(self, index, value)
+      if (exists) emitSplice(self, oldLength-1, 1, emptyArray, [value])
       emitReplace(self, SIZE, index, oldLength)
       return value
     }
@@ -51,7 +51,7 @@ const ArrayOverrides: any = {
     const oldLength = self.length
     if (values.length) {
       const length = self.push(...values)
-      emitSplice(self, oldLength, values, emptyArray)
+      emitSplice(self, oldLength-1, 1, values, emptyArray)
       emitReplace(self, SIZE, length, oldLength)
       return length
     }
@@ -61,7 +61,7 @@ const ArrayOverrides: any = {
     const self: any[] = this[$$]
     const oldValue = [...self]
     self.reverse()
-    emitSplice(self, 0, [...self], oldValue)
+    emitSplice(self, 0, oldValue.length, [...self], oldValue)
     return this
   },
   shift() {
@@ -70,7 +70,7 @@ const ArrayOverrides: any = {
     if (oldLength) {
       const exists = 0 in self
       const value = self.shift()
-      if (exists) emitRemove(self, 0, value)
+      if (exists) emitSplice(self, 0, 1, emptyArray, [value])
       emitReplace(self, SIZE, oldLength - 1, oldLength)
       return value
     }
@@ -79,7 +79,7 @@ const ArrayOverrides: any = {
     const self: any[] = this[$$]
     const oldValue = [...self]
     self.sort(compare)
-    emitSplice(self, 0, [...self], oldValue)
+    emitSplice(self, 0, oldValue.length, [...self], oldValue)
     return this
   },
   splice(start: number, removeCount = 0, ...values: any[]): any[] {
@@ -95,7 +95,7 @@ const ArrayOverrides: any = {
     const addCount = values.length
     if (addCount || removeCount) {
       const delta = addCount - removeCount
-      emitSplice(self, start, values, [...removed])
+      emitSplice(self, start, removeCount, [...values], [...removed])
       if (delta) emitReplace(self, SIZE, oldLength + delta, oldLength)
     }
     return removed
@@ -105,7 +105,7 @@ const ArrayOverrides: any = {
     const oldLength = self.length
     if (values.length) {
       const length = self.unshift(...values)
-      emitSplice(self, 0, values, emptyArray)
+      emitSplice(self, 0, 0, values, emptyArray)
       emitReplace(self, SIZE, length, oldLength)
       return length
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -60,8 +60,7 @@ const ArrayOverrides: any = {
   reverse() {
     const self: any[] = this[$$]
     const oldValue = [...self]
-    self.reverse()
-    emitSplice(self, 0, oldValue.length, [...self], oldValue)
+    emitSplice(self, 0, oldValue.length, [...self].reverse(), oldValue)
     return this
   },
   shift() {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -60,7 +60,8 @@ const ArrayOverrides: any = {
   reverse() {
     const self: any[] = this[$$]
     const oldValue = [...self]
-    emitSplice(self, 0, oldValue.length, [...self].reverse(), oldValue)
+    self.reverse()
+    emitSplice(self, 0, oldValue.length, [...self], oldValue)
     return this
   },
   shift() {


### PR DESCRIPTION
I need to enhance `emitSplice` for persistence purposes. The problem with the current implementation is there isn't enough information to record and reperform the change event at another time (it also seems to be applied inconsistently).

For example, `push`, `splice`, `reverse`, and `sort` events look exactly the same. If I get the information from the reverse event, I have no idea whether I should push those values to the end of the existing array, or replace the entire existing array.

I'd like to enhance the `emitSplice` event be modified so that it can be replicated using `Array.splice()` in the future (and also reversed for undo). For that, it needs an additional `removeCount` property and `emitSplice` should be used as the following:

```js
interface Change<T = any> {
  op: 'splice'
  target: object // target array
  key?: any // index at start of splice
  removeCount?: any // number of removed elements from index
  value?: T // an array of new inserted elements, empty array if none
  oldValue?: T // an array of old removed elements, empty array if none
}
```

All the array events can be expressed using `splice`, so I've replaced the emitters to be splices. I'm not sure if that has consequences when replacing the `remove` events from `shift` and `pop`.

It's a little weird having that `removeCount` there for only `splice` events, but without it, I can't reperform the event, or implement undo / redo. Let me know what you think!