### PR TITLE
feat: emit "define" events for defined properties

### DIFF
--- a/spec/__snapshots__/index.spec.ts.snap
+++ b/spec/__snapshots__/index.spec.ts.snap
@@ -487,6 +487,83 @@ Array [
 ]
 `;
 
+exports[`o(Object) [[DefineOwnProperty]] emits for new property 1`] = `
+Array [
+  Array [
+    Object {
+      "key": "a",
+      "oldValue": undefined,
+      "op": "define",
+      "target": Object {},
+      "value": Object {
+        "get": [Function],
+      },
+    },
+  ],
+  Array [
+    Object {
+      "key": "b",
+      "op": "add",
+      "target": Object {},
+      "value": 2,
+    },
+  ],
+]
+`;
+
+exports[`o(Object) [[DefineOwnProperty]] emits for redefined property 1`] = `
+Array [
+  Array [
+    Object {
+      "key": "a",
+      "oldValue": Object {
+        "configurable": true,
+        "enumerable": true,
+        "get": [Function],
+        "set": undefined,
+      },
+      "op": "define",
+      "target": Object {
+        "a": 4,
+      },
+      "value": Object {
+        "get": [Function],
+      },
+    },
+  ],
+  Array [
+    Object {
+      "key": "a",
+      "oldValue": Object {
+        "configurable": true,
+        "enumerable": true,
+        "get": [Function],
+        "set": undefined,
+      },
+      "op": "define",
+      "target": Object {
+        "a": 4,
+      },
+      "value": Object {
+        "value": 3,
+        "writable": true,
+      },
+    },
+  ],
+  Array [
+    Object {
+      "key": "a",
+      "oldValue": 3,
+      "op": "replace",
+      "target": Object {
+        "a": 4,
+      },
+      "value": 4,
+    },
+  ],
+]
+`;
+
 exports[`o(Object) [[Delete]] emits for known keys 1`] = `
 Array [
   Array [

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -157,6 +157,66 @@ describe('o(Object)', () => {
       obj.a = 1
       expect(calls).toEqual([])
     })
+
+    describe('own setter', () => {
+      it('is called with observable this', () => {
+        const obj = o({
+          get a() {
+            return 0
+          },
+          set a(_val) {
+            expect(this).toBe(obj)
+          },
+        })
+        obj.a = 1
+        expect.assertions(1)
+      })
+
+      it('is called without implicit observation', () => {
+        const obj = o({
+          get a() {
+            return 0
+          },
+          set a(_val) {
+            expect(globals.observe).toBe(null)
+          },
+        })
+        obj.a = 1
+        expect.assertions(1)
+      })
+    })
+
+    describe('inherited setter', () => {
+      it('is called with observable this', () => {
+        const obj: any = o({
+          __proto__: {
+            get a() {
+              return 0
+            },
+            set a(_val) {
+              expect(this).toBe(obj)
+            },
+          },
+        })
+        obj.a = 1
+        expect.assertions(1)
+      })
+
+      it('is called without implicit observation', () => {
+        const obj: any = o({
+          __proto__: {
+            get a() {
+              return 0
+            },
+            set a(_val) {
+              expect(globals.observe).toBe(null)
+            },
+          },
+        })
+        obj.a = 1
+        expect.assertions(1)
+      })
+    })
   })
 
   describe('[[Delete]]', () => {

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -172,16 +172,18 @@ describe('o(Object)', () => {
         expect.assertions(1)
       })
 
-      it('is called without implicit observation', () => {
+      it('can be observed', () => {
         const obj = o({
           get a() {
             return 0
           },
           set a(_val) {
-            expect(globals.observe).toBe(null)
+            expect(globals.observe).toBeTruthy()
           },
         })
-        obj.a = 1
+        auto(() => {
+          obj.a = 1
+        })
         expect.assertions(1)
       })
     })
@@ -202,18 +204,20 @@ describe('o(Object)', () => {
         expect.assertions(1)
       })
 
-      it('is called without implicit observation', () => {
+      it('can be observed', () => {
         const obj: any = o({
           __proto__: {
             get a() {
               return 0
             },
             set a(_val) {
-              expect(globals.observe).toBe(null)
+              expect(globals.observe).toBeTruthy()
             },
           },
         })
-        obj.a = 1
+        auto(() => {
+          obj.a = 1
+        })
         expect.assertions(1)
       })
     })

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -181,6 +181,52 @@ describe('o(Object)', () => {
     it.todo('tracks unknown keys')
     it.todo('tracks inherited keys')
   })
+
+  describe('[[DefineOwnProperty]]', () => {
+    it('emits for new property', () => {
+      const obj: any = o({})
+      const calls = watch(obj)
+
+      // 1. Define with "get" descriptor
+      Object.defineProperty(obj, 'a', {
+        get: () => 1,
+      })
+
+      // 2. Define with "value" descriptor
+      Object.defineProperty(obj, 'b', {
+        value: 2,
+      })
+
+      expect(calls).toMatchSnapshot()
+    })
+
+    it('emits for redefined property', () => {
+      const obj = o({
+        get a() {
+          return 1
+        },
+      })
+      const calls = watch(obj)
+
+      // 1. Redefine with "get" descriptor
+      Object.defineProperty(obj, 'a', {
+        get: () => 2,
+      })
+
+      // 2. Redefine with "value" descriptor
+      Object.defineProperty(obj, 'a', {
+        value: 3,
+        writable: true,
+      })
+
+      // 3. Redefine with "value" descriptor (again)
+      Object.defineProperty(obj, 'a', {
+        value: 4,
+      })
+
+      expect(calls).toMatchSnapshot()
+    })
+  })
 })
 
 describe('o(Array)', () => {

--- a/src/emit.ts
+++ b/src/emit.ts
@@ -90,3 +90,17 @@ export const emitClear = (target: object, oldValue: any) =>
     target,
     oldValue,
   })
+
+export const emitDefine = (
+  target: object,
+  key: keyof any,
+  value: PropertyDescriptor,
+  oldValue?: PropertyDescriptor
+) =>
+  emit(target, {
+    op: 'define',
+    target,
+    key,
+    value,
+    oldValue,
+  })

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -102,7 +102,7 @@ export class ObservedSlot extends Set<ChangeObserver> {
 
 /** An observed mutation of an observable object. */
 export interface Change<T = any> {
-  op: 'add' | 'replace' | 'remove' | 'splice' | 'clear'
+  op: 'add' | 'replace' | 'remove' | 'splice' | 'clear' | 'define'
   target: object
   key?: any
   value?: T


### PR DESCRIPTION
With these changes, using `Object.defineProperty` will emit a "define" event when (1) a getter is defined by the call, or (2) a getter is replaced by the call.

Not tested, but `Object.defineProperties` should work as well.